### PR TITLE
fixing dialogs

### DIFF
--- a/file_helper.py
+++ b/file_helper.py
@@ -69,7 +69,7 @@ def cache_tile(tile, source_name):
 
 
 def get_sample_data_directory():
-    return os.path.join(get_plugin_directory(), "sample_data")
+    return os.path.join(os.path.abspath(os.curdir))
 
 
 def get_home_directory():

--- a/ui/dialogs.py
+++ b/ui/dialogs.py
@@ -357,10 +357,12 @@ class ConnectionsDialog(QtGui.QDialog, Ui_DlgConnections):
         self.txtPath.setText("")
 
     def _get_current_connection(self):
-        if self.tabServer.isEnabled():
+
+        active_tab = self.tabConnections.currentWidget()
+        if active_tab == self.tabServer:
             name = self.cbxConnections.currentText()
             url = self.connections[name]
-        elif self.tabFile.isEnabled():
+        elif active_tab == self.tabFile:
             url = self.txtPath.text()
             name = os.path.basename(url)
         else:


### PR DESCRIPTION
The current code always opened data from remote server (default Mapzen) - ignoring other inputs (file).

This patch repaces not suitable `isEnabled()` method with `currentWidget()`, which seems to be more approriate.