### PR TITLE
version increased to 1.7.2

### DIFF
--- a/metadata.txt
+++ b/metadata.txt
@@ -8,7 +8,7 @@ qgisMinimumVersion=2.18
 qgisMaximumVersion=2.98
 description=Vector tiles reader which supports server connections, MBTiles file and other sources
 about=Reads vector tiles according to Mapbox Vector Tiles specification as layers in a group. Sources can be an internet server, from an MBTiles file or from a directory. This Python plugin uses prebuild C++ binaries for performance reasons.
-version=1.7.1
+version=1.7.2
 author=Martin Boos
 email=geometalab@gmail.com
 
@@ -18,8 +18,10 @@ email=geometalab@gmail.com
 
 # Uncomment the following line and add your changelog:
 changelog=
-    ---1.7.1---
+    ---1.7.2---
     * Bugfix: OTF was enabled before the new CRS was set, which removed and locked the map scale
+    ---1.7.1---
+    * Skipped
     ---1.7.0---
     * UI slightly changed
     * Directory connection improved


### PR DESCRIPTION
* Bugfix: OTF was enabled before the new CRS was set, which removed and locked the map scale