### PR TITLE
Changed homepage's URL in QGIS' metadata

### DIFF
--- a/metadata.txt
+++ b/metadata.txt
@@ -134,7 +134,7 @@ changelog=
 # Tags are comma separated with spaces allowed
 tags=vector tiles, tiles, mbtiles, mapbox, vector, basemap
 
-homepage=https://github.com/geometalab/Vector-Tiles-Reader-QGIS-Plugin/blob/master/README.md
+homepage=https://github.com/geometalab/Vector-Tiles-Reader-QGIS-Plugin/
 tracker=https://github.com/geometalab/Vector-Tiles-Reader-QGIS-Plugin/issues
 repository=https://github.com/geometalab/Vector-Tiles-Reader-QGIS-Plugin
 category=Vector


### PR DESCRIPTION
Currently, when clicking on homepage link in QGIS' plugins interface, you are directed to https://github.com/geometalab/Vector-Tiles-Reader-QGIS-Plugin/blob/master/README.md, which triggers a 404 error. I changed url to the repo instead.