### PR TITLE
Added small section to fix an issue with QGIS expression 

### DIFF
--- a/plugin/style_converter/core/__init__.py
+++ b/plugin/style_converter/core/__init__.py
@@ -378,6 +378,16 @@ def _parse_expr(expr, take=None):
                 raise RuntimeError("Data expression operator not implemented: ", op)
 
     fields = _get_qgis_fields(expr)[:take]
+
+    #issue starts here and can be checked for and fixed
+    #when the http_get returns byte information, that 'b' sometimes sticks to icon name
+    #simply check and if it is there, remove
+    b_string = "'b'"
+    for s, item in enumerate(fields):
+        if b_string in item:
+            new_item = item[2:-1]
+            fields[s] = new_item
+
     result = "+".join(fields)
     return escape_xml(result)
 


### PR DESCRIPTION
I was seeing a bug that was berried deep in the QGIS symbols. When the expression it built like [path]+[icon_name]... the icon name was keeping the 'b' from the byte date after the http_get(). This small section will just check and make sure there is no standalone 'b' and if there is then it will remove. The QGIS expressions are no longer invalid after this fix. 

To check for this issue in QGIS, you go to a symbol layer that is using icons, click on an icon > SVG Marker > scroll down to the expression that was inserted by the script and if that is red, it is invalid. That is this bug presenting. These few lines should fix that but also not cause other issues for examples where this is not happening. 