### PR TITLE
fix #276 first-loading-issue fix

### DIFF
--- a/plugin/vtr_plugin.py
+++ b/plugin/vtr_plugin.py
@@ -753,10 +753,6 @@ class VtrPlugin:
             else:
                 self._debouncer.pause()
 
-        if not is_add and not self._get_all_own_layers():
-            info("Loading aborted as there are no layers of the current connection already loaded.")
-            return
-
         merge_tiles = options.merge_tiles_enabled()
         apply_styles = options.apply_styles_enabled()
         tile_limit = options.tile_number_limit()


### PR DESCRIPTION
Removed some codes cause the problem.
By this, the plugin become not able to judge whether _load_tiles() is called by _on_add_layer() as FIRST loading or not.
I guess this is not important. The plugin is actually working.

Thanks.