### PR TITLE
add support to build/use libpbf2geojson on OpenBSD (fixes #280)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,9 @@ endif
 ifeq ($(detected_OS),Linux)
     CXXFLAGS += -fPIC
 endif
+ifeq ($(detected_OS),OpenBSD)
+    CXX = c++
+endif
 ifeq ($(detected_OS),Darwin)
     CXXFLAGS += -fPIC
     CXX = clang++
@@ -38,3 +41,6 @@ linux:
 osx:
 	$(CXX) -m64 $(CXXFLAGS) -o ./ext-libs/pbf2geojson/pbf2geojson_osx_x86_64.so ./ext-libs/pbf2geojson/pbf2geojson.cpp
 	$(CXX) -m32 $(CXXFLAGS) -o ./ext-libs/pbf2geojson/pbf2geojson_osx_i686.so ./ext-libs/pbf2geojson/pbf2geojson.cpp
+
+openbsd:
+	$(CXX) -fPIC -std=c++11 -I/usr/local/include -s -Os -Ofast -O3 --shared -o ./ext-libs/pbf2geojson/pbf2geojson_openbsd_x86_64.so ./ext-libs/pbf2geojson/pbf2geojson.cpp

--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,7 @@ ifeq ($(detected_OS),Linux)
     CXXFLAGS += -fPIC
 endif
 ifeq ($(detected_OS),OpenBSD)
+    CXXFLAGS += -fPIC -I/usr/local/include
     CXX = c++
 endif
 ifeq ($(detected_OS),Darwin)
@@ -43,4 +44,4 @@ osx:
 	$(CXX) -m32 $(CXXFLAGS) -o ./ext-libs/pbf2geojson/pbf2geojson_osx_i686.so ./ext-libs/pbf2geojson/pbf2geojson.cpp
 
 openbsd:
-	$(CXX) -fPIC -std=c++11 -I/usr/local/include -s -Os -Ofast -O3 --shared -o ./ext-libs/pbf2geojson/pbf2geojson_openbsd_x86_64.so ./ext-libs/pbf2geojson/pbf2geojson.cpp
+	$(CXX) $(CXXFLAGS) -o ./ext-libs/pbf2geojson/pbf2geojson_openbsd_x86_64.so ./ext-libs/pbf2geojson/pbf2geojson.cpp

--- a/Makefile
+++ b/Makefile
@@ -15,6 +15,9 @@ ifeq ($(detected_OS),OpenBSD)
     CXXFLAGS += -fPIC -I/usr/local/include
     CXX = c++
 endif
+ifeq ($(detected_OS),FreeBSD)
+    CXXFLAGS += -fPIC -I/usr/local/include
+endif
 ifeq ($(detected_OS),Darwin)
     CXXFLAGS += -fPIC
     CXX = clang++
@@ -45,3 +48,7 @@ osx:
 
 openbsd:
 	$(CXX) $(CXXFLAGS) -o ./ext-libs/pbf2geojson/pbf2geojson_openbsd_x86_64.so ./ext-libs/pbf2geojson/pbf2geojson.cpp
+
+freebsd:
+	$(CXX) -m64 $(CXXFLAGS) -o ./ext-libs/pbf2geojson/pbf2geojson_freebsd_x86_64.so ./ext-libs/pbf2geojson/pbf2geojson.cpp
+	$(CXX) -m32 $(CXXFLAGS) -o ./ext-libs/pbf2geojson/pbf2geojson_freebsd_i686.so ./ext-libs/pbf2geojson/pbf2geojson.cpp

--- a/plugin/util/mp_helper.py
+++ b/plugin/util/mp_helper.py
@@ -47,6 +47,8 @@ def _get_lib_path():
         lib = "pbf2geojson_osx_{}.so".format(bitness_string)
     elif sys.platform.startswith("openbsd"):
         lib = "pbf2geojson_openbsd_{}.so".format(bitness_string)
+    elif sys.platform.startswith("freebsd"):
+        lib = "pbf2geojson_freebsd_{}.so".format(bitness_string)
     if lib:
         temp_dir = get_temp_dir("native")
         lib_path = os.path.join(os.path.abspath(get_plugin_directory()), "ext-libs", "pbf2geojson", lib)

--- a/plugin/util/mp_helper.py
+++ b/plugin/util/mp_helper.py
@@ -45,6 +45,8 @@ def _get_lib_path():
         lib = "pbf2geojson_windows_{}.dll".format(bitness_string)
     elif sys.platform.startswith("darwin"):
         lib = "pbf2geojson_osx_{}.so".format(bitness_string)
+    elif sys.platform.startswith("openbsd"):
+        lib = "pbf2geojson_openbsd_{}.so".format(bitness_string)
     if lib:
         temp_dir = get_temp_dir("native")
         lib_path = os.path.join(os.path.abspath(get_plugin_directory()), "ext-libs", "pbf2geojson", lib)


### PR DESCRIPTION
with the makefile bit, i get this:

```
[15:39] daytona:/tmp/Vector-Tiles-Reader-QGIS-Plugin/ $
    gmake openbsd
c++ -fPIC -std=c++11 -I/usr/local/include -s -Os -Ofast -O3 --shared -o ./ext-libs/pbf2geojson/pbf2geojson_openbsd_x86_64.so ./ext-libs/pbf2geojson/pbf2geojson.cpp
```
and i can use the native lib:
```
2020-03-11T15:17:19     WARNING    Vector Tiles Reader 3.2.2 (Python 3.7.6)
2020-03-11T15:18:05     WARNING    Loading native lib...
2020-03-11T15:18:05     WARNING    Native decoding supported!!! (OpenBSD, 64bit)
```

@lbartoletti maybe you want the same for FreeBSD ?