### PR TITLE
Fixed issues encountered when testing OGC Vector Tiles implementation…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -109,3 +109,4 @@ ENV/
 
 # Rope project settings
 .ropeproject
+*.lnk


### PR DESCRIPTION
As part of [2023-06 OGC API sprint](https://developer.ogc.org/sprints/21/), I tested using this Plugin to view an implementation of OGC Vector Tiles. I encountered two errors:
- Infinity values resulting from the reprojection
- with and height not being integers

I'm submitting this pull request, which fixes these errors and allows the following endpoint to be viewed: https://maps.gnosis.earth/ogcapi/collections/NaturalEarth:physical:ne_10m_land/tiles/WebMercatorQuad?f=tilejson
